### PR TITLE
ci: add workflow dispatch and every 3 hours trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,13 @@
 name: Check scripts
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
       - main
-  # Run every day at 05:00 UTC
   schedule:
-    - cron: "0 5 * * *"
+    - cron: '0 */3 * * *' # every 3 hours
 
 permissions:
   contents: read


### PR DESCRIPTION
## What?

* [x] add workflow dispatch and every 3 hours trigger

<!-- Briefly explain what this PR does. -->

## Why?

By some reason, GitHub is not starting the workflow every day. Add a manual trigger and new 3h trigger to troubleshoot.

<!-- Briefly explain why this PR does it. Specify the reason of the changes. -->
