### PR TITLE
fix: update cast and forge to 1.3.5-0.1.5

### DIFF
--- a/lib/protocol_version_era.py
+++ b/lib/protocol_version_era.py
@@ -24,7 +24,7 @@ class Toolchain:
 PROTOCOL_TOOLCHAINS: dict[str, Toolchain] = {
     PROTOCOL_V30: Toolchain(
         yarn_version="1.22",
-        cast_forge_version="0.0.4",
+        cast_forge_version="1.3.5",
         cargo_version="1.80.0",
     ),
 }


### PR DESCRIPTION
## What?

Update cast and forge to 1.3.5-0.1.5 for Era.
